### PR TITLE
Support for sending commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ This is a Python client for the Electrolux Group API. It is a simple wrapper aro
 
 ### Usage
 ```bash
-usage: cli.py [-h] -k API_KEY -t ACCESS_TOKEN -r REFRESH_TOKEN
+usage: cli.py [-h] -k API_KEY -t ACCESS_TOKEN -r REFRESH_TOKEN {list,command} ...
+
+positional arguments:
+  {list,command}
 
 options:
   -h, --help        show this help message and exit
@@ -14,6 +17,19 @@ required arguments:
   -k API_KEY        API key received from Electrolux
   -t ACCESS_TOKEN   Access token received from Electrolux
   -r REFRESH_TOKEN  Refresh token received from Electrolux
+```
+
+#### Sending commands
+Commands to be sent must a proper JSON. You can use the `list` command to find keys that will be accepted by the appliance.
+
+For example, to change the fan speed for an air purifier you can use the following commands:
+```
+poetry run python3 src/cli.py -k $API_KEY -t $ACCESS_TOKEN -r $REFRESH_TOKEN command -d $APPLIANCE_ID -c '{"Workmode": "Manual"}'
+poetry run python3 src/cli.py -k $API_KEY -t $ACCESS_TOKEN -r $REFRESH_TOKEN command -d $APPLIANCE_ID -c '{"Fanspeed": 3}'
+```
+and to switch it to automatic mode you can use
+```
+poetry run python3 src/cli.py -k $API_KEY -t $ACCESS_TOKEN -r $REFRESH_TOKEN command -d $APPLIANCE_ID -c '{"Workmode": "Auto"}'
 ```
 
 ### Disclaimer

--- a/src/pyelectroluxgroup/api.py
+++ b/src/pyelectroluxgroup/api.py
@@ -20,7 +20,10 @@ class ElectroluxHubAPI:
             return self.token_manager.access_token
 
         response = await self.auth.request(
-            "post", "token/refresh", json={"refreshToken": self.token_manager.refresh_token}
+            "post",
+            "token/refresh",
+            json={"refreshToken": self.token_manager.refresh_token},
+            skip_auth_headers=True
         )
 
         response.raise_for_status()

--- a/src/pyelectroluxgroup/appliance.py
+++ b/src/pyelectroluxgroup/appliance.py
@@ -1,5 +1,7 @@
 from typing import Dict
 
+from aiohttp.client_exceptions import ClientResponseError
+
 from pyelectroluxgroup.auth import Auth
 
 
@@ -53,6 +55,16 @@ class Appliance:
     def state(self) -> dict:
         """Return the appliance reported state"""
         return self.state_data["properties"]["reported"]
+
+    async def send_command(self, command: Dict):
+        resp = await self.auth.request("put", f"appliances/{self.id}/command",
+                                      json=command)
+        try:
+            data = await resp.json()
+            resp.raise_for_status()
+        except ClientResponseError as e:
+            print(data)
+            raise e
 
     async def async_update(self):
         """Update the appliance data."""

--- a/src/pyelectroluxgroup/auth.py
+++ b/src/pyelectroluxgroup/auth.py
@@ -18,6 +18,7 @@ class Auth:
 
     async def request(self, method: str, path: str, **kwargs) -> ClientResponse:
         """Make a request."""
+        json = kwargs.get("json", None)
         headers = kwargs.get("headers")
 
         if headers is None:
@@ -30,5 +31,5 @@ class Auth:
         headers["x-api-key"] = self.api_key
 
         return await self.session.request(
-            method, f"{self.host}/{path}", headers=headers,
+            method, f"{self.host}/{path}", headers=headers, json=json
         )

--- a/src/pyelectroluxgroup/auth.py
+++ b/src/pyelectroluxgroup/auth.py
@@ -26,9 +26,10 @@ class Auth:
         else:
             headers = dict(headers)
 
-        access_token = await self.async_get_access_token()
-        headers["authorization"] = f"Bearer {access_token}"
-        headers["x-api-key"] = self.api_key
+        if not kwargs.get("skip_auth_headers", None):
+            access_token = await self.async_get_access_token()
+            headers["authorization"] = f"Bearer {access_token}"
+            headers["x-api-key"] = self.api_key
 
         return await self.session.request(
             method, f"{self.host}/{path}", headers=headers, json=json


### PR DESCRIPTION
Includes changes from https://github.com/JohNan/pyelectroluxgroup/pull/2 because of the `cli.py` shenanigans.

Adds  (rather naive, as in we don't check validity of the commands client side. This could be easily added if we're fine with assuming that all the command calls must match one of the keys returned from the `/state` endpoint) support for sending commands to the appliances. Also extends the CLI arguments to distinguish between listing appliances and sending out commands.