### PR TITLE
Add the CLI extras group in pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ## Electrolux Group API Client
 This is a Python client for the Electrolux Group API. It is a simple wrapper around the API, which allows you to interact with the API in a more Pythonic way.
 
+### Installation
+Use `poetry install --extras cli` to install dependencies for CLI and the library itself.
+
 ### Usage
 ```bash
 usage: cli.py [-h] -k API_KEY -t ACCESS_TOKEN -r REFRESH_TOKEN {list,command} ...

--- a/poetry.lock
+++ b/poetry.lock
@@ -141,6 +141,17 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "certifi"
+version = "2024.7.4"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = true
+python-versions = ">=3.6"
+files = [
+    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
+    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.4.1"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -456,7 +467,10 @@ files = [
 idna = ">=2.0"
 multidict = ">=4.0"
 
+[extras]
+cli = ["certifi"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f5c8a2a2b7310ed30aa9581a2a0082bf71df1e5c50c99c9ef53123ed4b64a8a6"
+content-hash = "99a23fa439990fd3aa8ed12382e3701c1b74f36e29c96a40407ddd113ce70b58"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ packages = [
 python = "^3.11"
 aiohttp = "^3.10.0"
 pyjwt = "^2.8.0"
+certifi = { version = "2024.7.4", optional = true }
+
+[tool.poetry.extras]
+cli = ["certifi"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This will allow us to track the CLI dependencies without cluttering the library package