### PR TITLE
Abstract the TokenManager class

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,40 @@ Use `poetry install --extras cli` to install dependencies for CLI and the librar
 usage: cli.py [-h] -k API_KEY -t ACCESS_TOKEN -r REFRESH_TOKEN {list,command} ...
 
 positional arguments:
-  {list,command}
+  {login,list,command}
 
 options:
   -h, --help        show this help message and exit
+```
 
-required arguments:
-  -k API_KEY        API key received from Electrolux
-  -t ACCESS_TOKEN   Access token received from Electrolux
-  -r REFRESH_TOKEN  Refresh token received from Electrolux
+#### Authentication
+Before being able to use the CLI, you'll need to provide access token, refresh token and API key.
+All of these can be obtained using the [developer dashboard](https://developer.electrolux.one/dashboard).
+
+To store credentials locally, use the `login` command:
+```
+poetry run python3 src/cli.py login -k $API_KEY -t $ACCESS_TOKEN -r $REFRESH_TOKEN
+```
+
+#### Listing devices
+To list all devices, use the `list` command:
+```
+poetry run python3 src/cli.py list
 ```
 
 #### Sending commands
-Commands to be sent must a proper JSON. You can use the `list` command to find keys that will be accepted by the appliance.
+Commands to be sent must be proper JSON.
+You can use the `list` command described above to find appliance IDs and commands that will be accepted by the appliance.
 
 For example, to change the fan speed for an air purifier you can use the following commands:
 ```
-poetry run python3 src/cli.py -k $API_KEY -t $ACCESS_TOKEN -r $REFRESH_TOKEN command -d $APPLIANCE_ID -c '{"Workmode": "Manual"}'
-poetry run python3 src/cli.py -k $API_KEY -t $ACCESS_TOKEN -r $REFRESH_TOKEN command -d $APPLIANCE_ID -c '{"Fanspeed": 3}'
+poetry run python3 src/cli.py command -d $APPLIANCE_ID -c '{"Workmode": "Manual"}'
+poetry run python3 src/cli.py command -d $APPLIANCE_ID -c '{"Fanspeed": 3}'
 ```
+
 and to switch it to automatic mode you can use
 ```
-poetry run python3 src/cli.py -k $API_KEY -t $ACCESS_TOKEN -r $REFRESH_TOKEN command -d $APPLIANCE_ID -c '{"Workmode": "Auto"}'
+poetry run python3 src/cli.py command -d $APPLIANCE_ID -c '{"Workmode": "Auto"}'
 ```
 
 ### Disclaimer

--- a/src/pyelectroluxgroup/api.py
+++ b/src/pyelectroluxgroup/api.py
@@ -10,19 +10,13 @@ from pyelectroluxgroup.token_manager import TokenManager
 class ElectroluxHubAPI:
     """Class to communicate with the ExampleHub API."""
 
-    def __init__(
-        self,
-        session: ClientSession,
-        access_token: str,
-        refresh_token: str,
-        api_key: str,
-    ):
+    def __init__(self, session: ClientSession, token_manager: TokenManager):
         """Initialize the API and store the auth so we can make requests."""
-        self.token_manager = TokenManager(access_token, refresh_token)
+        self.token_manager = token_manager
         self.auth = Auth(
             session,
             "https://api.developer.electrolux.one/api/v1",
-            api_key,
+            token_manager.api_key,
             self.async_get_access_token,
         )
 
@@ -39,7 +33,7 @@ class ElectroluxHubAPI:
 
         response.raise_for_status()
         data = await response.json()
-        self.token_manager.update_tokens(data["accessToken"], data["refreshToken"])
+        self.token_manager.update(data["accessToken"], data["refreshToken"])
 
         return self.token_manager.access_token
 

--- a/src/pyelectroluxgroup/token_manager.py
+++ b/src/pyelectroluxgroup/token_manager.py
@@ -1,4 +1,5 @@
 import logging
+from abc import ABC, abstractmethod
 from datetime import datetime
 
 import jwt
@@ -6,13 +7,13 @@ import jwt
 _LOGGER = logging.getLogger(__name__)
 
 
-class TokenManager:
+class TokenManager(ABC):
     """Token manager class."""
 
-    def __init__(self, access_token: str, refresh_token: str):
+    @abstractmethod
+    def __init__(self, access_token: str, refresh_token: str, api_key: str):
         """Initialize the token manager."""
-        self._access_token = access_token
-        self._refresh_token = refresh_token
+        self.update(access_token, refresh_token, api_key)
 
     @property
     def access_token(self) -> str:
@@ -24,10 +25,18 @@ class TokenManager:
         """Return the refresh token."""
         return self._refresh_token
 
-    def update_tokens(self, access_token: str, refresh_token: str):
+    @property
+    def api_key(self) -> str:
+        """Return the api key."""
+        return self._api_key
+
+    @abstractmethod
+    def update(self, access_token: str, refresh_token: str, api_key: str | None = None):
         """Update the tokens."""
         self._access_token = access_token
         self._refresh_token = refresh_token
+        if api_key is not None:
+            self._api_key = api_key
 
     def is_token_valid(self) -> bool:
         """Check token validity"""

--- a/src/pyelectroluxgroup/token_managers/filesystem.py
+++ b/src/pyelectroluxgroup/token_managers/filesystem.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from pyelectroluxgroup.token_manager import TokenManager
+
+
+class TokenManagerFileSystem(TokenManager):
+    """Token manager class, with filesystem based persistent storage."""
+
+    def __init__(self, storage_file: Path | None = None):
+        """Initialize the token manager."""
+        if storage_file is not None:
+            self._storage_file = storage_file
+        else:
+            self._storage_file = (
+                Path.home() / ".cache" / "pyelectroluxgroup" / "credentials"
+            )
+
+        # Make sure that the parent directory exists
+        (self._storage_file.parent).mkdir(parents=True, exist_ok=True)
+
+    def update(self, access_token: str, refresh_token: str, api_key: str | None = None):
+        """Update the tokens."""
+        super().update(access_token, refresh_token, api_key)
+        self.save()
+
+    def save(self):
+        """Save the tokens to filesystem."""
+        with open(self._storage_file, "w") as f:
+            json.dump(
+                {
+                    "access_token": self.access_token,
+                    "refresh_token": self.refresh_token,
+                    "api_key": self.api_key,
+                },
+                f,
+            )
+
+    def load(self):
+        """Load the tokens from filesystem."""
+        with open(self._storage_file) as f:
+            credentials = json.load(f)
+            self.update(
+                credentials.get("access_token"),
+                credentials.get("refresh_token"),
+                credentials.get("api_key"),
+            )


### PR DESCRIPTION
Based on https://github.com/JohNan/pyelectroluxgroup/issues/4


What's changed:
* made the `TokenManager` class abstract
* made the `ElectroluxHubAPI` consume a token_manager instance
* added the filesystem-backed persistence for tokens with `TokenManagerFileSystem`
* added `login` command to the CLI, relying on the above class

I've also made the `api_key` part of the TokenManager class (maybe it warrants a name change :sweat_smile:), so it can also be persisted.
Not sure if this is the way, as theoretically the apikey could be just exported as an env variable or similar, as it doesn't really change. But still IMHO it's cleaner to keep all the auth strings in a single place