### PR TITLE
Adds functionality for interactive and memory maps for robotic vacuum cleaners (RVCs)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -105,7 +105,7 @@ async def main():
                 for map in maps:
                     print(f"Map ID: {map.id}")
                     print(f"Map name: {map.name}")
-                    print(f"Zones:")
+                    print("Zones:")
                     for zone in map.zones:
                         print(f"  - Zone ID: {zone.id}")
                         print(f"    Name: {zone.name}")
@@ -113,7 +113,7 @@ async def main():
                         print(f"    Power Mode: {zone.power_mode}")
 
             except StopIteration:
-                print(f"Appliance with ID {args.appliance_id} was not found")        
+                print(f"Appliance with ID {args.appliance_id} was not found")
 
         if args.cmd == "memory_maps":
             try:
@@ -126,13 +126,13 @@ async def main():
                 for map in maps:
                     print(f"Map ID: {map.id}")
                     print(f"Map name: {map.name}")
-                    print(f"Zones:")
+                    print("Zones:")
                     for room in map.rooms:
                         print(f"  - Room ID: {room.id}")
                         print(f"    Name: {room.name}")
 
             except StopIteration:
-                print(f"Appliance with ID {args.appliance_id} was not found") 
+                print(f"Appliance with ID {args.appliance_id} was not found")
 
         if args.cmd == "command":
             try:

--- a/src/pyelectroluxgroup/appliance.py
+++ b/src/pyelectroluxgroup/appliance.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List
 
 from aiohttp.client_exceptions import ClientResponseError
 
-import pyelectroluxgroup
 from pyelectroluxgroup.auth import Auth
 from pyelectroluxgroup.map import InteractiveMap, MemoryMap
 
@@ -114,14 +113,10 @@ class Appliance:
         """Return the interactive maps for the Pure i8 and Pure i9 RVC appliances."""
         resp = await self.auth.request("get", f"appliances/{self.id}/interactiveMap")
         resp.raise_for_status()
-        return [
-            InteractiveMap(map_data) for map_data in await resp.json()
-        ]
-    
+        return [InteractiveMap(map_data) for map_data in await resp.json()]
+
     async def async_get_memory_maps(self) -> List[MemoryMap]:
         """Return the memory maps for the 700 series RVC appliances."""
         resp = await self.auth.request("get", f"appliances/{self.id}/memoryMap")
         resp.raise_for_status()
-        return [
-            MemoryMap(map_data) for map_data in await resp.json()
-        ]
+        return [MemoryMap(map_data) for map_data in await resp.json()]

--- a/src/pyelectroluxgroup/map.py
+++ b/src/pyelectroluxgroup/map.py
@@ -1,4 +1,5 @@
-from typing import Dict, Any
+from typing import Any, Dict
+
 
 class Area:
     """Class representing a zone in an interactive map."""
@@ -6,16 +7,17 @@ class Area:
     def __init__(self, data: Dict[str, Any]):
         """Initialize the zone with data."""
         self.data = data
-    
+
     @property
     def id(self) -> str:
         """Return the area ID."""
         return self.data["id"]
-    
+
     @property
     def name(self) -> str:
         """Return the area name."""
         return self.data["name"]
+
 
 class Zone(Area):
     """Class representing a zone in an interactive map."""
@@ -28,11 +30,12 @@ class Zone(Area):
     def type(self) -> str:
         """Return the zone type."""
         return self.data["zoneType"]
-    
+
     @property
     def power_mode(self) -> str:
         """Return the power mode of the zone."""
-        return self.data["powerMode"] 
+        return self.data["powerMode"]
+
 
 class Room(Area):
     """Class representing a room in a memory map."""
@@ -53,7 +56,7 @@ class Map:
     def id(self) -> str:
         """Return the map ID."""
         return self.data["id"]
-    
+
     @property
     def name(self) -> str:
         """Return the map name."""
@@ -63,17 +66,19 @@ class Map:
     def areas(self) -> list[Area]:
         return []
 
+
 class InteractiveMap(Map):
     """Class for interactive maps, used in Pure i8 and i9 RVCs."""
 
     def __init__(self, data: Dict[str, Any]):
         """Initialize the interactive map with data."""
         super().__init__(data)
-        self.zones = [Zone(zone) for zone in data["zones"]]
+        self.zones: list[Area] = [Zone(zone) for zone in data["zones"]]
 
     @property
     def areas(self) -> list[Area]:
-        return self.zones
+        return list(self.zones)
+
 
 class MemoryMap(Map):
     """Class for memory maps, used in 700 series RVCs."""
@@ -85,4 +90,4 @@ class MemoryMap(Map):
 
     @property
     def areas(self) -> list[Area]:
-        return self.rooms
+        return list(self.rooms)


### PR DESCRIPTION
Electrolux added [API functionality for maps for RVCs on June 18, 2025](https://developer.electrolux.one/news). The PR adds functionality for retrieving the maps. The original code already provides all functionality for constructing the ``CustomPlay`` command for zone cleaning following the update of the Electrolux API; however, retrieving the maps is necessary for translating between human-friendly names and IDs for maps and zones (rooms).

Unfortunately, there are two separate APIs, one for the Pure i8 and i9 series called [interactive maps](https://developer.electrolux.one/documentation/reference#getInteractiveMaps) and one for the 700 series called [memory maps](https://developer.electrolux.one/documentation/reference#getMemoryMaps). The interactive maps contain zones, and the memory maps contain rooms. I tried to unify things by creating two map classes that inherit from a joint base class. I did the same for zones and rooms, which inherit from a common area class.

I  added ``interactive_maps`` and ``memory_maps`` options (with the -d parameter like command) to ``cli.py``  for testing. All API calls are based on the Electrolux documentation, and I have tested the code for my two Pure i9 RVCs. I do, however, not have a 700 series vacuum, so I could not test the memory map functionality fully. I suggest that you either ask someone like @ivancoppa to test that before accepting the PR, or we could also remove the 700 functionality for this PR.

I have also tested the ``CustomPlay`` command to verify that I can send the RVCs to clean a specific area indicated in the map, using the returned data from the added functions.