### PR TITLE
Fix bug when there is a map with no zones

### DIFF
--- a/src/pyelectroluxgroup/map.py
+++ b/src/pyelectroluxgroup/map.py
@@ -73,7 +73,7 @@ class InteractiveMap(Map):
     def __init__(self, data: Dict[str, Any]):
         """Initialize the interactive map with data."""
         super().__init__(data)
-        self.zones: list[Area] = [Zone(zone) for zone in data["zones"]]
+        self.zones: list[Area] = [Zone(zone) for zone in data.get("zones") or []]
 
     @property
     def areas(self) -> list[Area]:
@@ -86,7 +86,7 @@ class MemoryMap(Map):
     def __init__(self, data: Dict[str, Any]):
         """Initialize the memory map with data."""
         super().__init__(data)
-        self.rooms = [Room(room) for room in data["rooms"]]
+        self.rooms: list[Area] = [Room(room) for room in data.get("rooms") or []]
 
     @property
     def areas(self) -> list[Area]:


### PR DESCRIPTION
The PR fixes a bug where the map code throws an exception when a map has no zones.

The error was described [in issue #173 of homeassistant-wellbeing](https://github.com/JohNan/homeassistant-wellbeing/issues/173#issuecomment-3046146494). It was caused by the Electroluc interactive map API returning `zones = None` instead of the expected `zones = []` when there is a map with no zones. The fix returns an empty list of zones instead in this case.

I have also tested to delete all maps for an RVC, but in this case, the API returns an empty list of maps, so the fix is only applied to the iterations over zones in the map. It is a corner case that can be solved by deleting maps without zones, but it would be nice to include this in the next update to reduce user confusion, as the Electrolux app can add tentative maps that initially do not have any zones.

